### PR TITLE
Drop line length lint which makes editing annoying

### DIFF
--- a/.markdown-lint.yml
+++ b/.markdown-lint.yml
@@ -3,9 +3,7 @@ MD010:
   # Include code blocks
   code_blocks: false
 
-MD013:
-  # Number of characters
-  line_length: 200
+MD013: false
 
 MD024:
   # Only check sibling headings


### PR DESCRIPTION
Setting a max-length means you have to break paragraphs into multiple lines which requires you to manually "rebalance" paragraphs when you edit them. One line, one paragraph works much better when maintaining existing docs - just turn on wrapping in your editor :)