### PR TITLE
Info about self-hosted runners github workflows

### DIFF
--- a/docs/xks/operator-guide/github.md
+++ b/docs/xks/operator-guide/github.md
@@ -65,8 +65,7 @@ jobs:
 
 ### Self-hosted runners
 
-GitHub workflows is still rather immature and have a number of features missing.
-One of these are that it's currently not possible to use self-hosted runners in github organization X while calling on workflows in github organization Y.
+It's currently not possible to use self-hosted runners hosted in GitHub organization X while calling on workflows in GitHub organization Y.
 
 To be able to use self-hosted runners you have to import the repository to organization X **not fork** the [workflow repository](https://github.com/XenitAB/azure-devops-templates)
 and make it public. Else private repositories located in organization X won't be able to find the workflows.

--- a/docs/xks/operator-guide/github.md
+++ b/docs/xks/operator-guide/github.md
@@ -68,7 +68,7 @@ jobs:
 It's currently not possible to use self-hosted runners hosted in GitHub organization X while calling on workflows in GitHub organization Y.
 
 To be able to use self-hosted runners you have to import the repository to organization X **not fork** the [workflow repository](https://github.com/XenitAB/azure-devops-templates)
-and make it public. Else private repositories located in organization X won't be able to find the workflows.
+and make it public. If you don't do this private repositories located in organization X won't be able to find the workflows.
 
 ### Azure Service Principal
 

--- a/docs/xks/operator-guide/github.md
+++ b/docs/xks/operator-guide/github.md
@@ -63,6 +63,14 @@ jobs:
       AZURE_CREDENTIALS_PROD: ${{ secrets.AZURE_CREDENTIALS_PROD }}
 ```
 
+### Self-hosted runners
+
+GitHub workflows is still rather immature and have a number of features missing.
+One of these are that it's currently not possible to use self-hosted runners in github organization X while calling on workflows in github organization Y.
+
+To be able to use self-hosted runners you have to import the repository to organization X **not fork** the [workflow repository](https://github.com/XenitAB/azure-devops-templates)
+and make it public. Else private repositories located in organization X won't be able to find the workflows.
+
 ### Azure Service Principal
 
 Create a Service Principal(SP) with the access that terraform requires to perform all the tasks you want.


### PR DESCRIPTION
Document the need for improted repositories that is public to save time for
people trying to use self-hosted runners.