### PR TITLE
Publish with node 14

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "16"
       - name: Test Build
         run: |
           yarn install --frozen-lockfile


### PR DESCRIPTION
Update to node 14 which is required by docusaurus 2.0 as introduced by #73.