### PR TITLE
cloud-iam: Add information about aad-pod-identity retries

### DIFF
--- a/docs/xks/developer-guide/cloud-iam.md
+++ b/docs/xks/developer-guide/cloud-iam.md
@@ -53,6 +53,8 @@ az login --identity
 az account show
 ```
 
+Make sure your application supports retries when retrieving tokens. Should at least be able to retry for 60 seconds. Read more about it [here](https://azure.github.io/aad-pod-identity/docs/best-practices/#retry-on-token-retrieval). More good practices can be found on the [aad-pod-identity docs](https://azure.github.io/aad-pod-identity/docs/best-practices).
+
 #### SDK
 
 A common scenario is that an application may need API access to an Azure resources through the API. In these cases the best solution is to use the language specific SDKs which will most of the time


### PR DESCRIPTION
It's a common issue that when a POD starts up on a node that haven't
used that specific credential before, it takes time to retrieve the
token. By configuring the application to support retries up to 60
seconds some of the common issues at startup may be resolved.