### PR TITLE
K8s 1.25 API documentation

### DIFF
--- a/docs/xks/developer-guide/api-migrations.md
+++ b/docs/xks/developer-guide/api-migrations.md
@@ -12,10 +12,12 @@ This page is about sharing that information.
 # Kubernetes 1.25
 
 ## CronJob
+
 Moving CronJob apiVersion from `batch/v1beta1` to `batch/v1`
 The only thing you need to do is to change the API version.
 
 From:
+
 ````yaml
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -32,10 +34,12 @@ metadata:
   name: foo
 ````
 ## HorizontalPodAutoscaler
+
 Moving HorizontalPodAutoscaler apiVersion from `autoscaling/v2beta1` to `autoscaling/v2`
 The only thing you need to do is to change the API version.
 
 From:
+
 ````yaml
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -52,10 +56,12 @@ metadata:
   name: foo
 ````
 ## PodDisruptionBudget
+
 Moving HorizontalPodAutoscaler apiVersion from `autoscaling/v2beta1` to `autoscaling/v2`
 The only thing you need to do is to change the API version.
 
 From:
+
 ````yaml
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -78,6 +84,7 @@ Other noticeable changes is that in `policy/v1` an empty `spec.selector {}` sele
 PodSecurityPolicy in the policy/v1beta1 API version will no longer be served in v1.25, and the PodSecurityPolicy admission controller will be removed. More informaiton can be found [here.](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#psp-v125)
 
 # Older versions
+
 ## SecretProviderClass v1alpha1 to v1
 
 Moving SecretProviderClass apiVersion from `secrets-store.csi.x-k8s.io/v1alpha1` to `secrets-store.csi.x-k8s.io/v1`.

--- a/docs/xks/developer-guide/api-migrations.md
+++ b/docs/xks/developer-guide/api-migrations.md
@@ -13,7 +13,7 @@ This page is about sharing that information.
 
 ## CronJob
 Moving CronJob apiVersion from `batch/v1beta1` to `batch/v1`
-So the only thing you need to do is to change is the API version.
+The only thing you need to do is to change the API version.
 
 From:
 ````yaml
@@ -33,7 +33,7 @@ metadata:
 ````
 ## HorizontalPodAutoscaler
 Moving HorizontalPodAutoscaler apiVersion from `autoscaling/v2beta1` to `autoscaling/v2`
-So the only thing you need to do is to change is the API version.
+The only thing you need to do is to change the API version.
 
 From:
 ````yaml
@@ -53,7 +53,7 @@ metadata:
 ````
 ## PodDisruptionBudget
 Moving HorizontalPodAutoscaler apiVersion from `autoscaling/v2beta1` to `autoscaling/v2`
-So the only thing you need to do is to change is the API version.
+The only thing you need to do is to change the API version.
 
 From:
 ````yaml

--- a/docs/xks/developer-guide/api-migrations.md
+++ b/docs/xks/developer-guide/api-migrations.md
@@ -13,7 +13,7 @@ This page is about sharing that information.
 
 ## CronJob
 Moving CronJob apiVersion from `batch/v1beta1` to `batch/v1`
-So what is needed is making changes according to:
+So the only thing you need to do is to change is the API version.
 
 From:
 ````yaml
@@ -33,7 +33,7 @@ metadata:
 ````
 ## HorizontalPodAutoscaler
 Moving HorizontalPodAutoscaler apiVersion from `autoscaling/v2beta1` to `autoscaling/v2`
-So what is needed is making changes according to:
+So the only thing you need to do is to change is the API version.
 
 From:
 ````yaml
@@ -53,7 +53,7 @@ metadata:
 ````
 ## PodDisruptionBudget
 Moving HorizontalPodAutoscaler apiVersion from `autoscaling/v2beta1` to `autoscaling/v2`
-So what is needed is making changes according to:
+So the only thing you need to do is to change is the API version.
 
 From:
 ````yaml

--- a/docs/xks/developer-guide/api-migrations.md
+++ b/docs/xks/developer-guide/api-migrations.md
@@ -9,6 +9,75 @@ resources if you are utilizing them, but we will of course inform you when it's 
 
 This page is about sharing that information.
 
+# Kubernetes 1.25
+
+## CronJob
+Moving CronJob apiVersion from `batch/v1beta1` to `batch/v1`
+So what is needed is making changes according to:
+
+From:
+````yaml
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: foo
+````
+
+To:
+
+````yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: foo
+````
+## HorizontalPodAutoscaler
+Moving HorizontalPodAutoscaler apiVersion from `autoscaling/v2beta1` to `autoscaling/v2`
+So what is needed is making changes according to:
+
+From:
+````yaml
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: foo
+````
+
+To:
+
+````yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: foo
+````
+## PodDisruptionBudget
+Moving HorizontalPodAutoscaler apiVersion from `autoscaling/v2beta1` to `autoscaling/v2`
+So what is needed is making changes according to:
+
+From:
+````yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: foo
+````
+
+To:
+
+````yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: foo
+````
+Other noticeable changes is that in `policy/v1` an empty `spec.selector {}` selects all pods in the namespace, when the previous `policy/v1beta1` did not select any pods.
+
+## PodSecurityPolicy
+
+PodSecurityPolicy in the policy/v1beta1 API version will no longer be served in v1.25, and the PodSecurityPolicy admission controller will be removed. More informaiton can be found [here.](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#psp-v125)
+
+# Older versions
 ## SecretProviderClass v1alpha1 to v1
 
 Moving SecretProviderClass apiVersion from `secrets-store.csi.x-k8s.io/v1alpha1` to `secrets-store.csi.x-k8s.io/v1`.

--- a/docs/xks/developer-guide/api-migrations.md
+++ b/docs/xks/developer-guide/api-migrations.md
@@ -9,9 +9,9 @@ resources if you are utilizing them, but we will of course inform you when it's 
 
 This page is about sharing that information.
 
-# Kubernetes 1.25
+## Kubernetes 1.25
 
-## CronJob
+### CronJob
 
 Moving CronJob apiVersion from `batch/v1beta1` to `batch/v1`
 The only thing you need to do is to change the API version.
@@ -33,7 +33,8 @@ kind: CronJob
 metadata:
   name: foo
 ````
-## HorizontalPodAutoscaler
+
+### HorizontalPodAutoscaler
 
 Moving HorizontalPodAutoscaler apiVersion from `autoscaling/v2beta1` to `autoscaling/v2`
 The only thing you need to do is to change the API version.
@@ -55,7 +56,8 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: foo
 ````
-## PodDisruptionBudget
+
+### PodDisruptionBudget
 
 Moving HorizontalPodAutoscaler apiVersion from `autoscaling/v2beta1` to `autoscaling/v2`
 The only thing you need to do is to change the API version.
@@ -77,15 +79,18 @@ kind: PodDisruptionBudget
 metadata:
   name: foo
 ````
+
 Other noticeable changes is that in `policy/v1` an empty `spec.selector {}` selects all pods in the namespace, when the previous `policy/v1beta1` did not select any pods.
 
-## PodSecurityPolicy
+### PodSecurityPolicy
 
 PodSecurityPolicy in the policy/v1beta1 API version will no longer be served in v1.25, and the PodSecurityPolicy admission controller will be removed. More informaiton can be found [here.](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#psp-v125)
 
-# Older versions
+This is not something that we use in XKF, but it is good to know.
 
-## SecretProviderClass v1alpha1 to v1
+## General API changes
+
+### SecretProviderClass v1alpha1 to v1
 
 Moving SecretProviderClass apiVersion from `secrets-store.csi.x-k8s.io/v1alpha1` to `secrets-store.csi.x-k8s.io/v1`.
 
@@ -123,7 +128,7 @@ spec:
         objectType: "<type>"
 ```
 
-## Flux sourcecontroller v1beta1 to v1beta2
+### Flux sourcecontroller v1beta1 to v1beta2
 
 The only thing that you need to change when moving source.toolkit.fluxcd.io from `source.toolkit.fluxcd.io/v1beta1`to `source.toolkit.fluxcd.io/v1beta2` is the API version.
 


### PR DESCRIPTION
Functionality is verified in our current 1.24 k8s cluster 
for PDB with `apiVersion: policy/v1`
for HPA with `apiVersion: autoscaling/v2`
for CronJob with `apiVersion: batch/v1`