### PR TITLE
update authors picture

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,20 +1,20 @@
 phillebaba:
   name: Philip Laine
-  title: DevOps Engineer
+  title: Expert DevOps Engineer
   url: https://github.com/phillebaba/
-  image_url: https://media-exp1.licdn.com/dms/image/C4E03AQG31KQ2xlivRA/profile-displayphoto-shrink_800_800/0/1598524888194?e=1655337600&v=beta&t=syoZr78rwDPb7Jj4d4B4opGNVCVZIa_3rmCkX-6oT2Q
+  image_url: https://media-exp1.licdn.com/dms/image/C4E03AQG31KQ2xlivRA/profile-displayphoto-shrink_800_800/0/1598524888194?e=1673481600&v=beta&t=lIA0UixRG6tq22FXe9IuxYKjiINqgVgkLw9hWMdqD_w
   email: philip.laine@xenit.se
 
 andersq:
   name: Anders Qvist
   title: Expert Engineer
   url: https://github.com/bittrance
-  image_url: https://media-exp1.licdn.com/dms/image/C5603AQETsc7IPBMeZg/profile-displayphoto-shrink_800_800/0/1516275947412?e=1655337600&v=beta&t=YGaLEyUu6DC041xPrzS_P2nSLHwsMWKEEIIhqkFxX-8
+  image_url: https://media-exp1.licdn.com/dms/image/C5603AQETsc7IPBMeZg/profile-displayphoto-shrink_800_800/0/1516275947412?e=1673481600&v=beta&t=zo3AriMbbg_yN4uAFtsvkSL3aPaGiOl5UZLbCa53WV4
   email: anders.qvist@xenit.se
 
 nissessenap:
   name: Edvin Norling
-  title: DevOps Engineer
+  title: Expert DevOps Engineer
   url: https://github.com/nissessenap
-  image_url: https://media-exp1.licdn.com/dms/image/C5603AQEtMiyg5yOAqQ/profile-displayphoto-shrink_800_800/0/1580133585786?e=1657152000&v=beta&t=eqKSebVCuKvnBtwx1PlHbTeN1pLM0POGz1T7O202XLY
+  image_url: https://media-exp1.licdn.com/dms/image/C5603AQEtMiyg5yOAqQ/profile-displayphoto-shrink_800_800/0/1580133585786?e=1673481600&v=beta&t=SXFrHWYPkM2jpaKESqhdVIQix65MQP1slsoTBXGOmrY
   email: edvin.norling@xenit.se


### PR DESCRIPTION
Linkedin have moved around picture resources.
We probably should do something better so we don't rely on them to store them on the same URI for ever.

But for now this is better then nothing.
I also update my and Philips title.